### PR TITLE
change focus to app if bell rings and app is not on focus

### DIFF
--- a/APP/src/main/main.js
+++ b/APP/src/main/main.js
@@ -95,9 +95,23 @@ app.whenReady().then(() => {
             message: message.toString()
           });
           
-          // Si el mensaje es del topic del timbre, enviar un evento especial
+          // Si el mensaje es del topic del timbre, enviar un evento especial y mostrar la ventana
           if (topic === 'casa/timbre') {
             mainWindow.webContents.send('doorbell-alert', message.toString());
+            
+            // Mostrar y enfocar la ventana
+            if (!mainWindow.isVisible()) {
+              mainWindow.show();
+            }
+            if (!mainWindow.isFocused()) {
+              mainWindow.focus();
+            }
+            // En algunos sistemas operativos, forzar que la ventana esté en primer plano
+            mainWindow.setAlwaysOnTop(true);
+            // Después de un breve momento, desactivar always on top
+            setTimeout(() => {
+              mainWindow.setAlwaysOnTop(false);
+            }, 3000);
           }
         }
       });

--- a/tester/brokerTest.html
+++ b/tester/brokerTest.html
@@ -228,6 +228,9 @@
                 Enviar mensaje
             </div>
             <div class="input-group">
+                <input type="text" id="topicInput" placeholder="Topic (ej: casa/timbre)" value="casa/timbre" autocomplete="off">
+            </div>
+            <div class="input-group">
                 <input type="text" id="messageInput" placeholder="Escribe un mensaje..." autocomplete="off">
                 <button id="sendBtn">Enviar</button>
             </div>
@@ -252,7 +255,7 @@
 
     <script>
         // Configuración WebSocket para proxy MQTT
-        const ws = new WebSocket('ws://localhost:8080');
+        const ws = new WebSocket('ws://localhost:1777');
         const topic = 'casa/timbre';
         const clientId = 'web_' + Math.random().toString(16).substr(2, 8);
         
@@ -261,6 +264,7 @@
         const statusText = document.getElementById('statusText');
         const messagesContainer = document.getElementById('messages');
         const messageInput = document.getElementById('messageInput');
+        const topicInput = document.getElementById('topicInput');
         const sendBtn = document.getElementById('sendBtn');
         
         // Manejo de conexión WebSocket
@@ -379,14 +383,16 @@
             const message = messageInput.value.trim();
             if (message.length === 0) return;
             
+            const customTopic = topicInput.value.trim() || topic;
+            
             ws.send(JSON.stringify({
                 type: 'publish',
-                topic: topic,
+                topic: customTopic,
                 message: message
             }));
             
-            console.log(`Mensaje enviado a ${topic}: ${message}`);
-            addMessage('Enviado', message);
+            console.log(`Mensaje enviado a ${customTopic}: ${message}`);
+            addMessage('Enviado', `Topic: ${customTopic} | ${message}`);
             messageInput.value = '';
         }
         

--- a/tester/proxy.js
+++ b/tester/proxy.js
@@ -61,7 +61,7 @@ wss.on('connection', function connection(ws) {
     });
 });
 
-const PORT = 8080;
+const PORT = 1777;
 server.listen(PORT, () => {
     console.log(`Proxy ejecutándose en puerto ${PORT}`);
 });


### PR DESCRIPTION
This pull request introduces improvements to the doorbell notification system and updates to the MQTT broker testing interface. Key changes include enhancing the behavior of the main application window when a doorbell notification is received, adding flexibility to specify custom MQTT topics in the testing interface, and updating the WebSocket port configuration.

### Doorbell Notification Enhancements:
* [`APP/src/main/main.js`](diffhunk://#diff-3fc895ddf8ca02a25cfba7a72c3b2c1809a91fa59c049f5e4fdb74bdc05e9b9dL98-R114): Modified the behavior when a doorbell notification (`casa/timbre` topic) is received. The main application window now becomes visible, focused, and temporarily set to "always on top" to ensure the notification is noticeable. This "always on top" setting is automatically disabled after 3 seconds.

### MQTT Broker Testing Interface Updates:
* [`tester/brokerTest.html`](diffhunk://#diff-a2062909f579266bf147e061fcd1ae88392e0ac6697f837e69c60298a071a6a5R230-R232): Added an input field (`#topicInput`) to allow users to specify a custom topic for publishing messages, defaulting to `casa/timbre`. The topic is dynamically used when sending messages. [[1]](diffhunk://#diff-a2062909f579266bf147e061fcd1ae88392e0ac6697f837e69c60298a071a6a5R230-R232) [[2]](diffhunk://#diff-a2062909f579266bf147e061fcd1ae88392e0ac6697f837e69c60298a071a6a5R267) [[3]](diffhunk://#diff-a2062909f579266bf147e061fcd1ae88392e0ac6697f837e69c60298a071a6a5R386-R395)
* [`tester/brokerTest.html`](diffhunk://#diff-a2062909f579266bf147e061fcd1ae88392e0ac6697f837e69c60298a071a6a5L255-R258): Updated the WebSocket connection URL to use port `1777` instead of `8080` to align with the new server configuration.

### WebSocket Server Configuration:
* [`tester/proxy.js`](diffhunk://#diff-b469884364242a774f2b52d289f26cc1cb72ce36614b7dd9375cd6ad408d12cdL64-R64): Changed the WebSocket server's listening port from `8080` to `1777` to match the updated testing interface configuration.